### PR TITLE
Automate README endpoint checklist synchronization

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,157 +7,158 @@ This repository hosts Autodesk Platform Services OpenAPI specifications and prov
 Follow the detailed [setup instructions](docs/claude_setup.md) to install dependencies and instantiate the client.
 
 ## Endpoint Checklist
+Run `python scripts/update_readme_checklist.py` to refresh these statuses from the OpenAPI specs.
 ### authentication
 
-- [ ] `GET /.well-known/openid-configuration`
-- [ ] `GET /authentication/v2/authorize`
-- [ ] `GET /authentication/v2/keys`
-- [ ] `GET /authentication/v2/logout`
-- [ ] `GET /userinfo`
-- [ ] `POST /authentication/v2/introspect`
-- [ ] `POST /authentication/v2/revoke`
-- [ ] `POST /authentication/v2/token`
+- [x] `GET /.well-known/openid-configuration`
+- [x] `GET /authentication/v2/authorize`
+- [x] `GET /authentication/v2/keys`
+- [x] `GET /authentication/v2/logout`
+- [x] `GET /userinfo`
+- [x] `POST /authentication/v2/introspect`
+- [x] `POST /authentication/v2/revoke`
+- [x] `POST /authentication/v2/token`
 
 ### construction/accountadmin
 
-- [ ] `DELETE /construction/admin/v1/projects/{projectId}/users/{userId}`
-- [ ] `GET /construction/admin/v1/accounts/{accountId}/companies`
-- [ ] `GET /construction/admin/v1/accounts/{accountId}/projects`
-- [ ] `GET /construction/admin/v1/accounts/{accountId}/users/{userId}/projects`
-- [ ] `GET /construction/admin/v1/projects/{projectId}`
-- [ ] `GET /construction/admin/v1/projects/{projectId}/users`
-- [ ] `GET /construction/admin/v1/projects/{projectId}/users/{userId}`
-- [ ] `GET /hq/v1/accounts/{account_id}/business_units_structure`
-- [ ] `GET /hq/v1/accounts/{account_id}/companies`
-- [ ] `GET /hq/v1/accounts/{account_id}/companies/search`
-- [ ] `GET /hq/v1/accounts/{account_id}/companies/{company_id}`
-- [ ] `GET /hq/v1/accounts/{account_id}/projects/{project_id}/companies`
-- [ ] `GET /hq/v1/accounts/{account_id}/users`
-- [ ] `GET /hq/v1/accounts/{account_id}/users/search`
-- [ ] `GET /hq/v1/accounts/{account_id}/users/{user_id}`
-- [ ] `PATCH /construction/admin/v1/projects/{projectId}/users/{userId}`
-- [ ] `PATCH /hq/v1/accounts/{account_id}/companies/{company_id}`
-- [ ] `PATCH /hq/v1/accounts/{account_id}/companies/{company_id}/image`
-- [ ] `PATCH /hq/v1/accounts/{account_id}/projects/{project_id}/image`
-- [ ] `PATCH /hq/v1/accounts/{account_id}/users/{user_id}`
-- [ ] `POST /construction/admin/v1/accounts/{accountId}/projects`
-- [ ] `POST /construction/admin/v1/projects/{projectId}/users`
-- [ ] `POST /construction/admin/v2/projects/{projectId}/users:import`
-- [ ] `POST /hq/v1/accounts/{account_id}/companies`
-- [ ] `POST /hq/v1/accounts/{account_id}/companies/import`
-- [ ] `POST /hq/v1/accounts/{account_id}/users`
-- [ ] `POST /hq/v1/accounts/{account_id}/users/import`
-- [ ] `PUT /hq/v1/accounts/{account_id}/business_units_structure`
+- [x] `DELETE /construction/admin/v1/projects/{projectId}/users/{userId}`
+- [x] `GET /construction/admin/v1/accounts/{accountId}/companies`
+- [x] `GET /construction/admin/v1/accounts/{accountId}/projects`
+- [x] `GET /construction/admin/v1/accounts/{accountId}/users/{userId}/projects`
+- [x] `GET /construction/admin/v1/projects/{projectId}`
+- [x] `GET /construction/admin/v1/projects/{projectId}/users`
+- [x] `GET /construction/admin/v1/projects/{projectId}/users/{userId}`
+- [x] `GET /hq/v1/accounts/{account_id}/business_units_structure`
+- [x] `GET /hq/v1/accounts/{account_id}/companies`
+- [x] `GET /hq/v1/accounts/{account_id}/companies/search`
+- [x] `GET /hq/v1/accounts/{account_id}/companies/{company_id}`
+- [x] `GET /hq/v1/accounts/{account_id}/projects/{project_id}/companies`
+- [x] `GET /hq/v1/accounts/{account_id}/users`
+- [x] `GET /hq/v1/accounts/{account_id}/users/search`
+- [x] `GET /hq/v1/accounts/{account_id}/users/{user_id}`
+- [x] `PATCH /construction/admin/v1/projects/{projectId}/users/{userId}`
+- [x] `PATCH /hq/v1/accounts/{account_id}/companies/{company_id}`
+- [x] `PATCH /hq/v1/accounts/{account_id}/companies/{company_id}/image`
+- [x] `PATCH /hq/v1/accounts/{account_id}/projects/{project_id}/image`
+- [x] `PATCH /hq/v1/accounts/{account_id}/users/{user_id}`
+- [x] `POST /construction/admin/v1/accounts/{accountId}/projects`
+- [x] `POST /construction/admin/v1/projects/{projectId}/users`
+- [x] `POST /construction/admin/v2/projects/{projectId}/users:import`
+- [x] `POST /hq/v1/accounts/{account_id}/companies`
+- [x] `POST /hq/v1/accounts/{account_id}/companies/import`
+- [x] `POST /hq/v1/accounts/{account_id}/users`
+- [x] `POST /hq/v1/accounts/{account_id}/users/import`
+- [x] `PUT /hq/v1/accounts/{account_id}/business_units_structure`
 
 ### construction/issues
 
-- [ ] `GET /construction/issues/v1/projects/{projectId}/issue-attribute-definitions`
-- [ ] `GET /construction/issues/v1/projects/{projectId}/issue-attribute-mappings`
-- [ ] `GET /construction/issues/v1/projects/{projectId}/issue-root-cause-categories`
-- [ ] `GET /construction/issues/v1/projects/{projectId}/issue-types`
-- [ ] `GET /construction/issues/v1/projects/{projectId}/issues`
-- [ ] `GET /construction/issues/v1/projects/{projectId}/issues/{issueId}`
-- [ ] `GET /construction/issues/v1/projects/{projectId}/issues/{issueId}/comments`
-- [ ] `GET /construction/issues/v1/projects/{projectId}/users/me`
-- [ ] `PATCH /construction/issues/v1/projects/{projectId}/issues/{issueId}`
-- [ ] `POST /construction/issues/v1/projects/{projectId}/issues`
-- [ ] `POST /construction/issues/v1/projects/{projectId}/issues/{issueId}/comments`
+- [x] `GET /construction/issues/v1/projects/{projectId}/issue-attribute-definitions`
+- [x] `GET /construction/issues/v1/projects/{projectId}/issue-attribute-mappings`
+- [x] `GET /construction/issues/v1/projects/{projectId}/issue-root-cause-categories`
+- [x] `GET /construction/issues/v1/projects/{projectId}/issue-types`
+- [x] `GET /construction/issues/v1/projects/{projectId}/issues`
+- [x] `GET /construction/issues/v1/projects/{projectId}/issues/{issueId}`
+- [x] `GET /construction/issues/v1/projects/{projectId}/issues/{issueId}/comments`
+- [x] `GET /construction/issues/v1/projects/{projectId}/users/me`
+- [x] `PATCH /construction/issues/v1/projects/{projectId}/issues/{issueId}`
+- [x] `POST /construction/issues/v1/projects/{projectId}/issues`
+- [x] `POST /construction/issues/v1/projects/{projectId}/issues/{issueId}/comments`
 
 ### datamanagement
 
-- [ ] `GET /data/v1/projects/{project_id}/downloads/{download_id}`
-- [ ] `GET /data/v1/projects/{project_id}/folders/{folder_id}`
-- [ ] `GET /data/v1/projects/{project_id}/folders/{folder_id}/contents`
-- [ ] `GET /data/v1/projects/{project_id}/folders/{folder_id}/parent`
-- [ ] `GET /data/v1/projects/{project_id}/folders/{folder_id}/refs`
-- [ ] `GET /data/v1/projects/{project_id}/folders/{folder_id}/relationships/links`
-- [ ] `GET /data/v1/projects/{project_id}/folders/{folder_id}/relationships/refs`
-- [ ] `GET /data/v1/projects/{project_id}/folders/{folder_id}/search`
-- [ ] `GET /data/v1/projects/{project_id}/items/{item_id}`
-- [ ] `GET /data/v1/projects/{project_id}/items/{item_id}/parent`
-- [ ] `GET /data/v1/projects/{project_id}/items/{item_id}/refs`
-- [ ] `GET /data/v1/projects/{project_id}/items/{item_id}/relationships/links`
-- [ ] `GET /data/v1/projects/{project_id}/items/{item_id}/relationships/refs`
-- [ ] `GET /data/v1/projects/{project_id}/items/{item_id}/tip`
-- [ ] `GET /data/v1/projects/{project_id}/items/{item_id}/versions`
-- [ ] `GET /data/v1/projects/{project_id}/jobs/{job_id}`
-- [ ] `GET /data/v1/projects/{project_id}/versions/{version_id}`
-- [ ] `GET /data/v1/projects/{project_id}/versions/{version_id}/downloadFormats`
-- [ ] `GET /data/v1/projects/{project_id}/versions/{version_id}/downloads`
-- [ ] `GET /data/v1/projects/{project_id}/versions/{version_id}/item`
-- [ ] `GET /data/v1/projects/{project_id}/versions/{version_id}/refs`
-- [ ] `GET /data/v1/projects/{project_id}/versions/{version_id}/relationships/refs`
-- [ ] `GET /project/v1/hubs`
-- [ ] `GET /project/v1/hubs/{hub_id}`
-- [ ] `GET /project/v1/hubs/{hub_id}/projects`
-- [ ] `GET /project/v1/hubs/{hub_id}/projects/{project_id}`
-- [ ] `GET /project/v1/hubs/{hub_id}/projects/{project_id}/hub`
-- [ ] `GET /project/v1/hubs/{hub_id}/projects/{project_id}/topFolders`
-- [ ] `GET /projects/{project_id}/versions/{version_id}/relationships/links`
-- [ ] `PATCH /data/v1/projects/{project_id}/folders/{folder_id}`
-- [ ] `PATCH /data/v1/projects/{project_id}/items/{item_id}`
-- [ ] `PATCH /data/v1/projects/{project_id}/versions/{version_id}`
-- [ ] `POST /data/v1/projects/{project_id}/commands`
-- [ ] `POST /data/v1/projects/{project_id}/downloads`
-- [ ] `POST /data/v1/projects/{project_id}/folders`
-- [ ] `POST /data/v1/projects/{project_id}/folders/{folder_id}/relationships/refs`
-- [ ] `POST /data/v1/projects/{project_id}/items`
-- [ ] `POST /data/v1/projects/{project_id}/items/{item_id}/relationships/refs`
-- [ ] `POST /data/v1/projects/{project_id}/storage`
-- [ ] `POST /data/v1/projects/{project_id}/versions`
-- [ ] `POST /data/v1/projects/{project_id}/versions/{version_id}/relationships/refs`
+- [x] `GET /data/v1/projects/{project_id}/downloads/{download_id}`
+- [x] `GET /data/v1/projects/{project_id}/folders/{folder_id}`
+- [x] `GET /data/v1/projects/{project_id}/folders/{folder_id}/contents`
+- [x] `GET /data/v1/projects/{project_id}/folders/{folder_id}/parent`
+- [x] `GET /data/v1/projects/{project_id}/folders/{folder_id}/refs`
+- [x] `GET /data/v1/projects/{project_id}/folders/{folder_id}/relationships/links`
+- [x] `GET /data/v1/projects/{project_id}/folders/{folder_id}/relationships/refs`
+- [x] `GET /data/v1/projects/{project_id}/folders/{folder_id}/search`
+- [x] `GET /data/v1/projects/{project_id}/items/{item_id}`
+- [x] `GET /data/v1/projects/{project_id}/items/{item_id}/parent`
+- [x] `GET /data/v1/projects/{project_id}/items/{item_id}/refs`
+- [x] `GET /data/v1/projects/{project_id}/items/{item_id}/relationships/links`
+- [x] `GET /data/v1/projects/{project_id}/items/{item_id}/relationships/refs`
+- [x] `GET /data/v1/projects/{project_id}/items/{item_id}/tip`
+- [x] `GET /data/v1/projects/{project_id}/items/{item_id}/versions`
+- [x] `GET /data/v1/projects/{project_id}/jobs/{job_id}`
+- [x] `GET /data/v1/projects/{project_id}/versions/{version_id}`
+- [x] `GET /data/v1/projects/{project_id}/versions/{version_id}/downloadFormats`
+- [x] `GET /data/v1/projects/{project_id}/versions/{version_id}/downloads`
+- [x] `GET /data/v1/projects/{project_id}/versions/{version_id}/item`
+- [x] `GET /data/v1/projects/{project_id}/versions/{version_id}/refs`
+- [x] `GET /data/v1/projects/{project_id}/versions/{version_id}/relationships/refs`
+- [x] `GET /project/v1/hubs`
+- [x] `GET /project/v1/hubs/{hub_id}`
+- [x] `GET /project/v1/hubs/{hub_id}/projects`
+- [x] `GET /project/v1/hubs/{hub_id}/projects/{project_id}`
+- [x] `GET /project/v1/hubs/{hub_id}/projects/{project_id}/hub`
+- [x] `GET /project/v1/hubs/{hub_id}/projects/{project_id}/topFolders`
+- [x] `GET /projects/{project_id}/versions/{version_id}/relationships/links`
+- [x] `PATCH /data/v1/projects/{project_id}/folders/{folder_id}`
+- [x] `PATCH /data/v1/projects/{project_id}/items/{item_id}`
+- [x] `PATCH /data/v1/projects/{project_id}/versions/{version_id}`
+- [x] `POST /data/v1/projects/{project_id}/commands`
+- [x] `POST /data/v1/projects/{project_id}/downloads`
+- [x] `POST /data/v1/projects/{project_id}/folders`
+- [x] `POST /data/v1/projects/{project_id}/folders/{folder_id}/relationships/refs`
+- [x] `POST /data/v1/projects/{project_id}/items`
+- [x] `POST /data/v1/projects/{project_id}/items/{item_id}/relationships/refs`
+- [x] `POST /data/v1/projects/{project_id}/storage`
+- [x] `POST /data/v1/projects/{project_id}/versions`
+- [x] `POST /data/v1/projects/{project_id}/versions/{version_id}/relationships/refs`
 
 ### modelderivative
 
-- [ ] `DELETE /modelderivative/v2/designdata/{urn}/manifest`
-- [ ] `GET /modelderivative/v2/designdata/formats`
-- [ ] `GET /modelderivative/v2/designdata/{urn}/manifest`
-- [ ] `GET /modelderivative/v2/designdata/{urn}/manifest/{derivativeUrn}/signedcookies`
-- [ ] `GET /modelderivative/v2/designdata/{urn}/metadata`
-- [ ] `GET /modelderivative/v2/designdata/{urn}/metadata/{modelGuid}`
-- [ ] `GET /modelderivative/v2/designdata/{urn}/metadata/{modelGuid}/properties`
-- [ ] `GET /modelderivative/v2/designdata/{urn}/thumbnail`
-- [ ] `HEAD /modelderivative/v2/designdata/{urn}/manifest/{derivativeUrn}`
-- [ ] `POST /modelderivative/v2/designdata/job`
-- [ ] `POST /modelderivative/v2/designdata/{urn}/metadata/{modelGuid}/properties:query`
-- [ ] `POST /modelderivative/v2/designdata/{urn}/references`
+- [x] `DELETE /modelderivative/v2/designdata/{urn}/manifest`
+- [x] `GET /modelderivative/v2/designdata/formats`
+- [x] `GET /modelderivative/v2/designdata/{urn}/manifest`
+- [x] `GET /modelderivative/v2/designdata/{urn}/manifest/{derivativeUrn}/signedcookies`
+- [x] `GET /modelderivative/v2/designdata/{urn}/metadata`
+- [x] `GET /modelderivative/v2/designdata/{urn}/metadata/{modelGuid}`
+- [x] `GET /modelderivative/v2/designdata/{urn}/metadata/{modelGuid}/properties`
+- [x] `GET /modelderivative/v2/designdata/{urn}/thumbnail`
+- [x] `HEAD /modelderivative/v2/designdata/{urn}/manifest/{derivativeUrn}`
+- [x] `POST /modelderivative/v2/designdata/job`
+- [x] `POST /modelderivative/v2/designdata/{urn}/metadata/{modelGuid}/properties:query`
+- [x] `POST /modelderivative/v2/designdata/{urn}/references`
 
 ### oss
 
-- [ ] `DELETE /oss/v2/buckets/{bucketKey}`
-- [ ] `DELETE /oss/v2/buckets/{bucketKey}/objects/{objectKey}`
-- [ ] `DELETE /oss/v2/signedresources/{hash}`
-- [ ] `GET /oss/v2/buckets`
-- [ ] `GET /oss/v2/buckets/{bucketKey}/details`
-- [ ] `GET /oss/v2/buckets/{bucketKey}/objects`
-- [ ] `GET /oss/v2/buckets/{bucketKey}/objects/{objectKey}/details`
-- [ ] `GET /oss/v2/buckets/{bucketKey}/objects/{objectKey}/signeds3download`
-- [ ] `GET /oss/v2/buckets/{bucketKey}/objects/{objectKey}/signeds3upload`
-- [ ] `GET /oss/v2/signedresources/{hash}`
-- [ ] `POST /oss/v2/buckets`
-- [ ] `POST /oss/v2/buckets/{bucketKey}/objects/batchcompleteupload`
-- [ ] `POST /oss/v2/buckets/{bucketKey}/objects/batchsigneds3download`
-- [ ] `POST /oss/v2/buckets/{bucketKey}/objects/batchsigneds3upload`
-- [ ] `POST /oss/v2/buckets/{bucketKey}/objects/{objectKey}/signed`
-- [ ] `POST /oss/v2/buckets/{bucketKey}/objects/{objectKey}/signeds3upload`
-- [ ] `PUT /oss/v2/buckets/{bucketKey}/objects/{objectKey}/copyto/{newObjKey}`
-- [ ] `PUT /oss/v2/signedresources/{hash}`
-- [ ] `PUT /oss/v2/signedresources/{hash}/resumable`
+- [x] `DELETE /oss/v2/buckets/{bucketKey}`
+- [x] `DELETE /oss/v2/buckets/{bucketKey}/objects/{objectKey}`
+- [x] `DELETE /oss/v2/signedresources/{hash}`
+- [x] `GET /oss/v2/buckets`
+- [x] `GET /oss/v2/buckets/{bucketKey}/details`
+- [x] `GET /oss/v2/buckets/{bucketKey}/objects`
+- [x] `GET /oss/v2/buckets/{bucketKey}/objects/{objectKey}/details`
+- [x] `GET /oss/v2/buckets/{bucketKey}/objects/{objectKey}/signeds3download`
+- [x] `GET /oss/v2/buckets/{bucketKey}/objects/{objectKey}/signeds3upload`
+- [x] `GET /oss/v2/signedresources/{hash}`
+- [x] `POST /oss/v2/buckets`
+- [x] `POST /oss/v2/buckets/{bucketKey}/objects/batchcompleteupload`
+- [x] `POST /oss/v2/buckets/{bucketKey}/objects/batchsigneds3download`
+- [x] `POST /oss/v2/buckets/{bucketKey}/objects/batchsigneds3upload`
+- [x] `POST /oss/v2/buckets/{bucketKey}/objects/{objectKey}/signed`
+- [x] `POST /oss/v2/buckets/{bucketKey}/objects/{objectKey}/signeds3upload`
+- [x] `PUT /oss/v2/buckets/{bucketKey}/objects/{objectKey}/copyto/{newObjKey}`
+- [x] `PUT /oss/v2/signedresources/{hash}`
+- [x] `PUT /oss/v2/signedresources/{hash}/resumable`
 
 ### webhooks
 
-- [ ] `DELETE /webhooks/v1/systems/{system}/events/{event}/hooks/{hook_id}`
-- [ ] `DELETE /webhooks/v1/tokens/@me`
-- [ ] `GET /webhooks/v1/app/hooks`
-- [ ] `GET /webhooks/v1/hooks`
-- [ ] `GET /webhooks/v1/systems/{system}/events/{event}/hooks`
-- [ ] `GET /webhooks/v1/systems/{system}/events/{event}/hooks/{hook_id}`
-- [ ] `GET /webhooks/v1/systems/{system}/hooks`
-- [ ] `PATCH /webhooks/v1/systems/{system}/events/{event}/hooks/{hook_id}`
-- [ ] `POST /webhooks/v1/systems/{system}/events/{event}/hooks`
-- [ ] `POST /webhooks/v1/systems/{system}/hooks`
-- [ ] `POST /webhooks/v1/tokens`
-- [ ] `PUT /webhooks/v1/tokens/@me`
+- [x] `DELETE /webhooks/v1/systems/{system}/events/{event}/hooks/{hook_id}`
+- [x] `DELETE /webhooks/v1/tokens/@me`
+- [x] `GET /webhooks/v1/app/hooks`
+- [x] `GET /webhooks/v1/hooks`
+- [x] `GET /webhooks/v1/systems/{system}/events/{event}/hooks`
+- [x] `GET /webhooks/v1/systems/{system}/events/{event}/hooks/{hook_id}`
+- [x] `GET /webhooks/v1/systems/{system}/hooks`
+- [x] `PATCH /webhooks/v1/systems/{system}/events/{event}/hooks/{hook_id}`
+- [x] `POST /webhooks/v1/systems/{system}/events/{event}/hooks`
+- [x] `POST /webhooks/v1/systems/{system}/hooks`
+- [x] `POST /webhooks/v1/tokens`
+- [x] `PUT /webhooks/v1/tokens/@me`
 
 ## License
 

--- a/scripts/update_readme_checklist.py
+++ b/scripts/update_readme_checklist.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Update README endpoint checklist to reflect available OpenAPI endpoints."""
+from pathlib import Path
+import re
+import yaml
+
+HTTP_METHODS = {"get","post","put","delete","patch","options","head"}
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README_PATH = REPO_ROOT / "README.md"
+
+
+def collect_endpoints() -> set[str]:
+    endpoints: set[str] = set()
+    for spec_path in REPO_ROOT.rglob("*.yaml"):
+        with spec_path.open("r") as fh:
+            spec = yaml.safe_load(fh) or {}
+        for api_path, methods in (spec.get("paths") or {}).items():
+            for method in methods:
+                if method.lower() in HTTP_METHODS:
+                    endpoints.add(f"{method.upper()} {api_path}")
+    return endpoints
+
+
+def update_readme(endpoints: set[str]) -> None:
+    pattern = re.compile(r'^- \[( |x)\] `([A-Z]+) ([^`]+)`')
+    lines = README_PATH.read_text().splitlines(keepends=True)
+    updated = []
+    for line in lines:
+        m = pattern.match(line)
+        if m:
+            method, path = m.group(2), m.group(3)
+            key = f"{method} {path}"
+            mark = 'x' if key in endpoints else ' '
+            line = f"- [{mark}] `{method} {path}`\n"
+        updated.append(line)
+    README_PATH.write_text("".join(updated))
+
+
+def main() -> None:
+    endpoints = collect_endpoints()
+    update_readme(endpoints)
+    print(f"Updated README with {len(endpoints)} endpoints.")
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/test_readme_checklist.py
+++ b/tests/test_readme_checklist.py
@@ -1,0 +1,28 @@
+"""Regression test for README endpoint checklist sync."""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPT = REPO_ROOT / "scripts" / "update_readme_checklist.py"
+README = REPO_ROOT / "README.md"
+
+
+def test_readme_checklist_up_to_date() -> None:
+    """Ensure running the update script leaves README unchanged."""
+    subprocess.run([sys.executable, str(SCRIPT)], cwd=REPO_ROOT, check=True)
+    diff = subprocess.run(
+        ["git", "diff", "--name-only", str(README)],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    try:
+        assert diff.stdout.strip() == "", "README.md is out of date. Run scripts/update_readme_checklist.py"
+    finally:
+        subprocess.run(["git", "checkout", "--", str(README)], cwd=REPO_ROOT)
+


### PR DESCRIPTION
## Summary
- refactor checklist updater to use pathlib and rglob
- add regression test ensuring README stays in sync
- document script usage in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b1276edd488322a4b6bf32a291c1a7