### PR TITLE
Namespace MCP client endpoints with verbose logging, async support, and history

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ This repository hosts Autodesk Platform Services OpenAPI specifications and prov
 
 Follow the detailed [setup instructions](docs/claude_setup.md) to install dependencies and instantiate the client.
 
+## MCP Client Features
+
+This client dynamically exposes APS APIs through a namespaced structure and logs
+every request for maximum transparency.
+
+- [x] Dynamic loading of OpenAPI specifications
+- [x] Namespaced endpoint groups for compartmentalization
+- [x] Verbose logging of requests and responses
+- [x] Request/response history for context preservation
+- [x] Async endpoint support
+- [x] Operation metadata (ID, summary, description) captured in history
+- [x] Docstrings enumerate parameters and body details for each endpoint
+
 ## Endpoint Checklist
 Run `python scripts/update_readme_checklist.py` to refresh these statuses from the OpenAPI specs.
 ### authentication

--- a/mcp/__init__.py
+++ b/mcp/__init__.py
@@ -1,3 +1,3 @@
-from .client import AutodeskMCP
+from .client import AutodeskMCP, AutodeskMCPAsync, RequestRecord
 
-__all__ = ['AutodeskMCP']
+__all__ = ["AutodeskMCP", "AutodeskMCPAsync", "RequestRecord"]

--- a/mcp/client.py
+++ b/mcp/client.py
@@ -1,48 +1,205 @@
+import logging
 import os
 import re
-import yaml
+from dataclasses import dataclass
+from types import SimpleNamespace
+
+import httpx
 import requests
+import yaml
+
+logger = logging.getLogger(__name__)
 
 HTTP_METHODS = {"get", "post", "put", "delete", "patch", "options", "head"}
 
-class AutodeskMCP:
-    """Dynamic client that loads APS OpenAPI specs and exposes endpoints as methods."""
 
-    def __init__(self, base_url: str = "https://developer.api.autodesk.com", token: str | None = None):
+@dataclass
+class RequestRecord:
+    operation_id: str
+    summary: str
+    description: str
+    method: str
+    url: str
+    path_params: dict | None
+    query: dict | None
+    data: dict | None
+    headers: dict
+    status_code: int
+    response_headers: dict
+    response_body: str
+
+
+class _BaseMCP:
+    """Common loader for APS OpenAPI specs and dynamic endpoint creation."""
+
+    def __init__(
+        self,
+        session,
+        base_url: str = "https://developer.api.autodesk.com",
+        *,
+        token: str | None = None,
+        verbose: bool = True,
+    ):
         self.base_url = base_url.rstrip("/")
-        self.session = requests.Session()
+        self.session = session
         if token:
             self.session.headers.update({"Authorization": f"Bearer {token}"})
-        self.endpoints: dict[str, dict] = {}
+        self.verbose = verbose
+        if self.verbose:
+            logging.basicConfig(level=logging.INFO)
+        self.endpoints: dict[str, dict[str, dict]] = {}
+        self.history: list[RequestRecord] = []
         self._load_specs()
-        self._build_methods()
+        self._build_namespaces()
 
     def _load_specs(self) -> None:
-        repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+        repo_root = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
         for dirpath, _dirnames, filenames in os.walk(repo_root):
             for fname in filenames:
-                if fname.endswith('.yaml'):
-                    with open(os.path.join(dirpath, fname), 'r') as f:
-                        spec = yaml.safe_load(f)
+                if fname.endswith(".yaml"):
+                    with open(os.path.join(dirpath, fname), "r") as f:
+                        spec = yaml.safe_load(f) or {}
                     category = os.path.relpath(dirpath, repo_root)
-                    for api_path, methods in spec.get('paths', {}).items():
-                        for method, details in methods.items():
+                    for api_path, path_item in spec.get("paths", {}).items():
+                        path_params = path_item.get("parameters", [])
+                        for method, details in path_item.items():
                             if method.lower() in HTTP_METHODS:
-                                op_id = details.get('operationId') or f"{method}_{api_path}"
-                                key = f"{category}.{op_id}"
-                                self.endpoints[key] = {"method": method.upper(), "path": api_path}
+                                op_id = details.get("operationId") or f"{method}_{api_path}"
+                                params = path_params + details.get("parameters", [])
+                                request_body = details.get("requestBody", {})
+                                entry = {
+                                    "method": method.upper(),
+                                    "path": api_path,
+                                    "summary": details.get("summary", ""),
+                                    "description": details.get("description", ""),
+                                    "parameters": params,
+                                    "request_body": request_body.get("description", ""),
+                                }
+                                self.endpoints.setdefault(category, {})[op_id] = entry
 
-    def _build_methods(self) -> None:
-        for key, data in self.endpoints.items():
-            func_name = self._sanitize(key)
-            setattr(self, func_name, self._make_call(data["method"], data["path"]))
+    def _build_namespaces(self) -> None:
+        for category, endpoints in self.endpoints.items():
+            namespace = self._ensure_namespace(category)
+            for op_id, data in endpoints.items():
+                func_name = self._sanitize(op_id)
+                setattr(
+                    namespace,
+                    func_name,
+                    self._make_call(
+                        op_id,
+                        data["method"],
+                        data["path"],
+                        summary=data.get("summary", ""),
+                        description=data.get("description", ""),
+                        parameters=data.get("parameters"),
+                        request_body=data.get("request_body"),
+                    ),
+                )
 
-    def _make_call(self, method: str, path: str):
-        def call(path_params: dict | None = None, query: dict | None = None, data: dict | None = None, headers: dict | None = None):
+    def _ensure_namespace(self, category: str) -> SimpleNamespace:
+        current = self
+        for part in category.split(os.sep):
+            attr = self._sanitize(part)
+            if not hasattr(current, attr):
+                setattr(current, attr, SimpleNamespace())
+            current = getattr(current, attr)
+        return current
+
+    def _make_call(
+        self,
+        operation_id: str,
+        method: str,
+        path: str,
+        *,
+        summary: str = "",
+        description: str = "",
+        parameters: list | None = None,
+        request_body: str | None = None,
+    ):
+        raise NotImplementedError
+
+    def _sanitize(self, key: str) -> str:
+        return re.sub(r"[^0-9a-zA-Z_]", "_", key)
+
+    def list_endpoints(self) -> list[str]:
+        items: list[str] = []
+        for category, endpoints in self.endpoints.items():
+            for op_id in endpoints:
+                items.append(f"{category}.{op_id}")
+        return sorted(items)
+
+
+class AutodeskMCP(_BaseMCP):
+    """Synchronous client that exposes APS APIs through dynamic namespaces."""
+
+    def __init__(
+        self,
+        base_url: str = "https://developer.api.autodesk.com",
+        token: str | None = None,
+        verbose: bool = True,
+    ):
+        session = requests.Session()
+        super().__init__(session, base_url, token=token, verbose=verbose)
+
+    def _make_call(
+        self,
+        operation_id: str,
+        method: str,
+        path: str,
+        *,
+        summary: str = "",
+        description: str = "",
+        parameters: list | None = None,
+        request_body: str | None = None,
+    ):
+        def call(
+            path_params: dict | None = None,
+            query: dict | None = None,
+            data: dict | None = None,
+            headers: dict | None = None,
+        ):
             url = self.base_url + path
             if path_params:
                 url = url.format(**path_params)
-            resp = self.session.request(method, url, params=query, json=data, headers=headers)
+            req_headers = self.session.headers.copy()
+            if headers:
+                req_headers.update(headers)
+            if self.verbose:
+                logger.info("Operation: %s", operation_id)
+                if summary:
+                    logger.info("  summary=%s", summary)
+                if description:
+                    logger.info("  description=%s", description)
+                logger.info("Request: %s %s", method, url)
+                if path_params:
+                    logger.info("  path_params=%s", path_params)
+                if query:
+                    logger.info("  query=%s", query)
+                if data:
+                    logger.info("  data=%s", data)
+                if req_headers:
+                    logger.info("  headers=%s", req_headers)
+            resp = self.session.request(method, url, params=query, json=data, headers=req_headers)
+            if self.verbose:
+                logger.info("Response: %s", resp.status_code)
+                logger.info("  headers=%s", dict(resp.headers))
+                logger.info("  body=%s", resp.text)
+            self.history.append(
+                RequestRecord(
+                    operation_id,
+                    summary,
+                    description,
+                    method,
+                    url,
+                    path_params,
+                    query,
+                    data,
+                    req_headers,
+                    resp.status_code,
+                    dict(resp.headers),
+                    resp.text,
+                )
+            )
             resp.raise_for_status()
             if not resp.content:
                 return None
@@ -50,11 +207,125 @@ class AutodeskMCP:
                 return resp.json()
             except ValueError:
                 return resp.text
-        call.__name__ = method + '_' + self._sanitize(path)
+
+        call.__name__ = method.lower() + "_" + self._sanitize(path)
+        doc = f"{operation_id}: {method} {path}"
+        if summary or description:
+            doc += f"\n\n{summary}"
+            if description:
+                doc += f"\n\n{description}"
+        if parameters:
+            doc += "\n\nParameters:\n"
+            for p in parameters:
+                name = p.get("name", "")
+                loc = p.get("in", "")
+                required = "required" if p.get("required") else "optional"
+                desc = p.get("description", "")
+                doc += f"- {name} ({loc}, {required}) {desc}\n"
+        if request_body:
+            doc += f"\nRequest Body: {request_body}\n"
+        call.__doc__ = doc
         return call
 
-    def _sanitize(self, key: str) -> str:
-        return re.sub(r'[^0-9a-zA-Z_]', '_', key)
 
-    def list_endpoints(self) -> list[str]:
-        return sorted(self.endpoints.keys())
+class AutodeskMCPAsync(_BaseMCP):
+    """Asynchronous client that mirrors :class:`AutodeskMCP` using httpx."""
+
+    def __init__(
+        self,
+        base_url: str = "https://developer.api.autodesk.com",
+        token: str | None = None,
+        verbose: bool = True,
+    ):
+        session = httpx.AsyncClient()
+        super().__init__(session, base_url, token=token, verbose=verbose)
+
+    async def close(self) -> None:
+        await self.session.aclose()
+
+    def _make_call(
+        self,
+        operation_id: str,
+        method: str,
+        path: str,
+        *,
+        summary: str = "",
+        description: str = "",
+        parameters: list | None = None,
+        request_body: str | None = None,
+    ):
+        async def call(
+            path_params: dict | None = None,
+            query: dict | None = None,
+            data: dict | None = None,
+            headers: dict | None = None,
+        ):
+            url = self.base_url + path
+            if path_params:
+                url = url.format(**path_params)
+            req_headers = self.session.headers.copy()
+            if headers:
+                req_headers.update(headers)
+            if self.verbose:
+                logger.info("Operation: %s", operation_id)
+                if summary:
+                    logger.info("  summary=%s", summary)
+                if description:
+                    logger.info("  description=%s", description)
+                logger.info("Request: %s %s", method, url)
+                if path_params:
+                    logger.info("  path_params=%s", path_params)
+                if query:
+                    logger.info("  query=%s", query)
+                if data:
+                    logger.info("  data=%s", data)
+                if req_headers:
+                    logger.info("  headers=%s", req_headers)
+            resp = await self.session.request(method, url, params=query, json=data, headers=req_headers)
+            if self.verbose:
+                logger.info("Response: %s", resp.status_code)
+                logger.info("  headers=%s", dict(resp.headers))
+                logger.info("  body=%s", resp.text)
+            self.history.append(
+                RequestRecord(
+                    operation_id,
+                    summary,
+                    description,
+                    method,
+                    url,
+                    path_params,
+                    query,
+                    data,
+                    req_headers,
+                    resp.status_code,
+                    dict(resp.headers),
+                    resp.text,
+                )
+            )
+            resp.raise_for_status()
+            if not resp.content:
+                return None
+            try:
+                return resp.json()
+            except ValueError:
+                return resp.text
+
+        call.__name__ = method.lower() + "_" + self._sanitize(path)
+        doc = f"{operation_id}: {method} {path}"
+        if summary or description:
+            doc += f"\n\n{summary}"
+            if description:
+                doc += f"\n\n{description}"
+        if parameters:
+            doc += "\n\nParameters:\n"
+            for p in parameters:
+                name = p.get("name", "")
+                loc = p.get("in", "")
+                required = "required" if p.get("required") else "optional"
+                desc = p.get("description", "")
+                doc += f"- {name} ({loc}, {required}) {desc}\n"
+        if request_body:
+            doc += f"\nRequest Body: {request_body}\n"
+        call.__doc__ = doc
+        return call
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.31
 PyYAML>=6.0
+httpx>=0.24

--- a/tests/test_async_client.py
+++ b/tests/test_async_client.py
@@ -1,0 +1,49 @@
+import asyncio
+import inspect
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from mcp import AutodeskMCPAsync  # noqa: E402
+
+
+def test_async_methods_are_coroutines():
+    client = AutodeskMCPAsync(base_url="https://example.com", verbose=False)
+    auth_ns = client.authentication
+    method = next(iter(vars(auth_ns).values()))
+    assert inspect.iscoroutinefunction(method)
+    asyncio.run(client.close())
+
+def test_async_history(monkeypatch):
+    async def run():
+        client = AutodeskMCPAsync(base_url="https://example.com", verbose=False)
+
+        async def fake_request(method, url, params=None, json=None, headers=None):
+            class Resp:
+                status_code = 200
+                headers = {"Content-Type": "application/json"}
+                text = '{"ok": true}'
+                content = b'{"ok": true}'
+
+                def json(self):
+                    return {"ok": True}
+
+                def raise_for_status(self):
+                    pass
+
+            return Resp()
+
+        monkeypatch.setattr(client.session, "request", fake_request)
+        await client.authentication.get_user_info()
+        assert len(client.history) == 1
+        record = client.history[0]
+        assert record.operation_id == "get-user-info"
+        assert record.method == "GET"
+        assert record.url.endswith("/userinfo")
+        assert record.status_code == 200
+        assert record.description == "Retrieves information about the authenticated user."
+        assert record.response_body == '{"ok": true}'
+        await client.close()
+
+    asyncio.run(run())
+

--- a/tests/test_history.py
+++ b/tests/test_history.py
@@ -1,0 +1,37 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from mcp import AutodeskMCP  # noqa: E402
+
+
+def test_sync_history(monkeypatch):
+    client = AutodeskMCP(base_url="https://example.com", verbose=False)
+
+    def fake_request(method, url, params=None, json=None, headers=None):
+        class Resp:
+            status_code = 200
+            headers = {"Content-Type": "application/json"}
+            text = '{"ok": true}'
+            content = b'{"ok": true}'
+
+            def json(self):
+                return {"ok": True}
+
+            def raise_for_status(self):
+                pass
+
+        return Resp()
+
+    monkeypatch.setattr(client.session, "request", fake_request)
+    client.authentication.get_user_info()
+    assert len(client.history) == 1
+    record = client.history[0]
+    assert record.operation_id == "get-user-info"
+    assert record.method == "GET"
+    assert record.url.endswith("/userinfo")
+    assert record.status_code == 200
+    assert record.description == "Retrieves information about the authenticated user."
+    assert record.response_body == '{"ok": true}'


### PR DESCRIPTION
## Summary
- capture operation ID, summary, and description for each API call and expose them in `RequestRecord`
- load OpenAPI parameter and body metadata to build verbose endpoint docstrings
- test sync and async clients record operation metadata for request history

## Testing
- `python scripts/update_readme_checklist.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2184fbd688322a13fa143ba882f1e